### PR TITLE
fix/authentication

### DIFF
--- a/backend/src/application/errors/http.ts
+++ b/backend/src/application/errors/http.ts
@@ -4,3 +4,11 @@ export class UnauthorizedError extends Error {
     this.name = 'UnauthorizedError'
   }
 }
+
+export class ServerError extends Error {
+  constructor (stack: string) {
+    super('Internal Server Error')
+    this.name = 'ServerError'
+    this.stack = stack
+  }
+}

--- a/backend/src/application/errors/index.ts
+++ b/backend/src/application/errors/index.ts
@@ -1,1 +1,2 @@
 export * from './validation'
+export * from './http'

--- a/backend/src/application/helpers/http.ts
+++ b/backend/src/application/helpers/http.ts
@@ -1,3 +1,5 @@
+import { ServerError, UnauthorizedError } from '@/application/errors'
+
 export type HttpResponse<T = any> = {
   statusCode: number
   data: T
@@ -13,7 +15,12 @@ export const badRequest = (error: Error): HttpResponse<Error> => ({
   data: error
 })
 
-export const forbidden = (error: Error): HttpResponse<Error> => ({
+export const forbidden = (): HttpResponse<Error> => ({
   statusCode: 403,
-  data: error
+  data: new UnauthorizedError()
+})
+
+export const serverError = (error: Error): HttpResponse => ({
+  statusCode: 500,
+  data: new ServerError(error.stack)
 })

--- a/backend/src/main/adapters/express-middleware.ts
+++ b/backend/src/main/adapters/express-middleware.ts
@@ -8,9 +8,13 @@ export const adaptMiddleware = (middleware: Middleware) => {
       headers: req.headers
     }
 
+    if (!req.locals) {
+      req.locals = {}
+    }
+
     const httpResponse = await middleware.handle(httpRequest)
     if (httpResponse.statusCode === 200) {
-      Object.assign(req, httpResponse.data)
+      Object.assign(req.locals, httpResponse.data)
       next()
     } else {
       res.status(httpResponse.statusCode).json({

--- a/backend/src/main/middlewares/authentication.ts
+++ b/backend/src/main/middlewares/authentication.ts
@@ -1,10 +1,10 @@
 import { UnauthorizedError } from '@/application/errors/http'
-import { HttpResponse, forbidden, ok } from '@/application/helpers'
+import { HttpResponse, forbidden, ok, serverError } from '@/application/helpers'
 import { Middleware } from '@/application/middlewares'
 import { LoadUserById } from '@/domain/contracts/repos/user'
 import env from '@/main/config/env'
 
-import jwt from 'jsonwebtoken'
+import jwt, { JsonWebTokenError } from 'jsonwebtoken'
 
 export class AuthMiddleware implements Middleware {
   constructor (
@@ -14,12 +14,16 @@ export class AuthMiddleware implements Middleware {
   async handle (httpRequest: any): Promise<HttpResponse> {
     const authorization = httpRequest.headers.authorization
 
+    if (!authorization) {
+      return forbidden()
+    }
+
     try {
       const [, token] = authorization.split(' ')
       const decoded = <{id: number}>jwt.verify(token, env.jwtSecret)
 
       if (!decoded?.id) {
-        return forbidden(new UnauthorizedError())
+        return forbidden()
       } else {
 
         const user = this.loadUserById.loadById({ id: decoded.id })
@@ -28,13 +32,14 @@ export class AuthMiddleware implements Middleware {
           return ok({ requesterId: decoded.id })
         }
 
-        return forbidden(new UnauthorizedError())
+        return forbidden()
       }
     } catch (error) {
-      return {
-        statusCode: 500,
-        data: new Error('InternalServerError')
+      if (error instanceof JsonWebTokenError) {
+        return forbidden()
       }
+
+      return serverError(error)
     }
   }
 }


### PR DESCRIPTION
Removido o parâmetro do http forbidden helper.

Adicionado http serverError helper.

Atualizado a lógica do authentication para checar se o erro é de validação do JWT e retornar um erro de acordo.

Atualizado o adaptMiddleware para injetar a resposta do middleware no req.locals